### PR TITLE
Security System: Turn off the zones together when the alarm is disarmed

### DIFF
--- a/docs/SecuritySystem.md
+++ b/docs/SecuritySystem.md
@@ -34,7 +34,8 @@ as a button to trigger an alarm.
           ],
           "armAwayButtonLabel": "Arm Away",
           "armNightButtonLabel": "Arm Night",
-          "armStayButtonLabel": "Arm Stay"
+          "armStayButtonLabel": "Arm Stay",
+          "turnOffZonesWhenDisarming": false
         }
       ]
     }
@@ -54,6 +55,7 @@ as a button to trigger an alarm.
 | armAwayButtonLabel | No | The label of the button to Arm the alarm in the "Away" mode (Default "[Name] Arm Away") |
 | armNightButtonLabel | No | The label of the button to Arm the alarm in the "Night" mode (Default "[Name] Arm Night") |
 | armStayButtonLabel | No | The label of the button to Arm the alarm in the "Home" mode (Default "[Name]Arm Stay") |
+| turnOffZonesWhenDisarming  | No | Set this to ```true``` to turn off all the zones when disarming the alarm |
 
 See [configuration](Configuration.md) for more advanced configuration examples.
 

--- a/src/SecuritySystemAccessory.js
+++ b/src/SecuritySystemAccessory.js
@@ -26,6 +26,7 @@ class SecuritySystemAccessory {
     this.armAwayButtonLabel = config.armAwayButtonLabel || `${this.name} Arm Away`;
     this.armStayButtonLabel = config.armStayButtonLabel || `${this.name} Arm Stay`;
     this.armNightButtonLabel = config.armNightButtonLabel || `${this.name} Arm Night`;
+    this.turnOffZonesWhenDisarming = config.turnOffZonesWhenDisarming || false;
 
     this._storage = storage;
 
@@ -135,19 +136,21 @@ class SecuritySystemAccessory {
   }
 
   getZoneServices() {
-    let services = [];
+    let zoneServices = {};
 
     for (let zoneLabel of this.zones) {
       const zoneSwitch = new Service.Switch(`${this.name} ${zoneLabel} Zone`, `zone-${zoneLabel}`);
 
       zoneSwitch.getCharacteristic(Characteristic.On)
         .on('set', (value, callback) => this._setAlarm(zoneLabel, value, callback))
-        .updateValue(this._state.zonesAlarm[zoneLabel] || false);
+        .updateValue(this._isZoneAlarmed(zoneLabel));
 
-      services.push(zoneSwitch);
+      zoneServices[zoneLabel] = zoneSwitch;
     }
 
-    return services;
+    this._zoneServices = zoneServices;
+
+    return Object.values(this._zoneServices);
   }
 
   identify(callback) {
@@ -160,6 +163,13 @@ class SecuritySystemAccessory {
 
     const data = clone(this._state);
     data.targetState = value;
+
+    if (this.turnOffZonesWhenDisarming) {
+      for (let zoneLabel in data.zonesAlarm) {
+        data.zonesAlarm[zoneLabel] = false;
+      }
+    }
+
     this._persist(data, callback);
   }
 
@@ -208,6 +218,10 @@ class SecuritySystemAccessory {
     return this._state.targetState === Characteristic.SecuritySystemCurrentState.NIGHT_ARM;
   }
 
+  _isZoneAlarmed(zoneLabel) {
+    return this._state.zonesAlarm[zoneLabel] || false;
+  }
+
   _persist(data, callback) {
     this._storage.store(data, (error) => {
       if (error) {
@@ -247,6 +261,12 @@ class SecuritySystemAccessory {
     this._armNightSwitchService
       .getCharacteristic(Characteristic.On)
       .updateValue(this._isArmNight());
+
+    for (let zoneLabel in this._zoneServices) {
+      this._zoneServices[zoneLabel]
+        .getCharacteristic(Characteristic.On)
+        .updateValue(this._isZoneAlarmed(zoneLabel));
+    }
   }
 }
 


### PR DESCRIPTION
Scenario: the alarm is set to "Away". One of the zones is triggered by one sensor. The alarm is now "Alarm". Turn the alarm to Off. Turn the alarm to "Away" again will automatically go to "Alarm" because one or more zones are still activated. We should give the option to automatically turn off / reset the zones when turning off the alarm.